### PR TITLE
Add McDstQA, McDstCut and pythia8gen to McDst project.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ converters_optdebug: CXXFLAGS += -O2 -g
 converters_optdebug: converters
 converters: urqmd2mc pythia8
 urqmd2mc: urqmd2mc.cpp
-	$(CXX) $(CXXFLAGS) -I$(INCS) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(LIBS)
+	$(CXX) $(CXXFLAGS) -I$(INCS) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(LIBS) -U__ROOT__
 pythia8: pythia8gen.cpp
-	$(CXX) $(CXXFLAGS) -I$(INCS) $(shell pythia8-config --cflags) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(shell pythia8-config --libs) $(LIBS)
+	$(CXX) $(CXXFLAGS) -I$(INCS) $(shell pythia8-config --cflags) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(shell pythia8-config --libs) $(LIBS) -U__ROOT__

--- a/Makefile
+++ b/Makefile
@@ -45,5 +45,8 @@ converters_debug: CXXFLAGS += -O0 -g
 converters_debug: converters
 converters_optdebug: CXXFLAGS += -O2 -g
 converters_optdebug: converters
-converters: urqmd2mc.cpp
+converters: urqmd2mc pythia8
+urqmd2mc: urqmd2mc.cpp
 	$(CXX) $(CXXFLAGS) -I$(INCS) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(LIBS)
+pythia8: pythia8gen.cpp
+	$(CXX) $(CXXFLAGS) -I$(INCS) $(shell pythia8-config --cflags) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(shell pythia8-config --libs) $(LIBS)

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ converters_optdebug: CXXFLAGS += -O2 -g
 converters_optdebug: converters
 converters: urqmd2mc pythia8
 urqmd2mc: urqmd2mc.cpp
-	$(CXX) $(CXXFLAGS) -I$(INCS) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(LIBS) -U__ROOT__
+	$(CXX) $(CXXFLAGS) -I$(INCS) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(LIBS)
 pythia8: pythia8gen.cpp
-	$(CXX) $(CXXFLAGS) -I$(INCS) $(shell pythia8-config --cflags) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(shell pythia8-config --libs) $(LIBS) -U__ROOT__
+	$(CXX) $(CXXFLAGS) -I$(INCS) $(shell pythia8-config --cflags) $^ -o $(patsubst %.cpp,%,$<) -L. -l$(patsubst lib%.so,%,$(MCDST)) $(shell pythia8-config --libs) $(LIBS)

--- a/McDstCut.cxx
+++ b/McDstCut.cxx
@@ -60,10 +60,10 @@ void McDstCut::setPtHigh(float val)
   ptCut[1] = val;
 }
 
-bool McDstCut::isGoodParticle(float eta, float pt, int pdg)
+bool McDstCut::isGoodParticle(const TLorentzVector &v, int pdg)
 {
-  if (eta > etaCut[0] && eta < etaCut[1] &&
-      pt > ptCut[0] && pt < ptCut[1] &&
+  if (v.Eta() > etaCut[0] && v.Eta() < etaCut[1] &&
+      v.Pt() > ptCut[0] && v.Pt() < ptCut[1] &&
       checkExcludePdg(pdg) == false)
   {
     return true;

--- a/McDstCut.cxx
+++ b/McDstCut.cxx
@@ -7,10 +7,11 @@
 
 McDstCut::McDstCut()
 {
-  etaCut[0] = -999.;
-  etaCut[1] = 999.;
-  ptCut[0] = -999.;
-  ptCut[1] = -999.;
+  // We are using INFINITY IEEE 754.
+  etaCut[0] = -INFINITY;
+  ptCut[0] = -INFINITY;
+  etaCut[1] = INFINITY;
+  ptCut[1] = INFINITY;
 }
 
 McDstCut::McDstCut(const McDstCut &copy)

--- a/McDstCut.cxx
+++ b/McDstCut.cxx
@@ -1,0 +1,81 @@
+/*
+  Copyright (c) 2020 Nikita (arei) Ermakov <coffe92@gmail.com>
+  SPDX-License-Identifier: MIT
+*/
+
+#include "McDstCut.h"
+
+McDstCut::McDstCut()
+{
+  etaCut[0] = -999.;
+  etaCut[1] = 999.;
+  ptCut[0] = -999.;
+  ptCut[1] = -999.;
+}
+
+McDstCut::McDstCut(const McDstCut &copy)
+{
+  etaCut[0] = copy.etaCut[0];
+  etaCut[1] = copy.etaCut[1];
+  ptCut[0] = copy.ptCut[0];
+  ptCut[1] = copy.ptCut[1];
+  pdgExclude = copy.pdgExclude;
+}
+
+void McDstCut::excludePdg(int pdg)
+{
+  pdgExclude.push_back(pdg);
+}
+
+void McDstCut::setEta(float lo, float hi)
+{
+  etaCut[0] = lo;
+  etaCut[1] = hi;
+}
+
+void McDstCut::setEtaLow(float val)
+{
+  etaCut[0] = val;
+}
+
+void McDstCut::setEtaHigh(float val)
+{
+  etaCut[1] = val;
+}
+
+void McDstCut::setPt(float lo, float hi)
+{
+  ptCut[0] = lo;
+  ptCut[1] = hi;
+}
+
+void McDstCut::setPtLow(float val)
+{
+  ptCut[0] = val;
+}
+
+void McDstCut::setPtHigh(float val)
+{
+  ptCut[1] = val;
+}
+
+bool McDstCut::isGoodParticle(float eta, float pt, int pdg)
+{
+  if (eta > etaCut[0] && eta < etaCut[1] &&
+      pt > ptCut[0] && pt < ptCut[1] &&
+      checkExcludePdg(pdg) == false)
+  {
+    return true;
+  }
+  return false;
+}
+
+bool McDstCut::checkExcludePdg(int pdg)
+{
+  for (std::vector<int>::iterator i = pdgExclude.begin(); i != pdgExclude.end(); ++i)
+  {
+    if (*i == pdg)
+      return true;
+  }
+  return false;
+}

--- a/McDstCut.h
+++ b/McDstCut.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <TObject.h>
+#include <math.h>
 
 class McDstCut
 {

--- a/McDstCut.h
+++ b/McDstCut.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <TObject.h>
+#include <TLorentzVector.h>
 #include <math.h>
 
 class McDstCut
@@ -34,7 +35,7 @@ public:
   /*
     Check parameters of the particle.
   */
-  bool isGoodParticle(float eta, float pt, int pdg);
+  bool isGoodParticle(const TLorentzVector &v, int pdg);
 
 private:
   std::vector<int> pdgExclude;

--- a/McDstCut.h
+++ b/McDstCut.h
@@ -1,0 +1,50 @@
+/*
+  Copyright (c) 2020 Nikita (arei) Ermakov <coffe92@gmail.com>
+  SPDX-License-Identifier: MIT
+*/
+
+#ifndef McDstCut_h
+#define McDstCut_h
+
+#include <vector>
+#include <TObject.h>
+
+class McDstCut
+{
+public:
+  /*
+    By default all cuts are off, i.e. has large ranges.
+  */
+  McDstCut();
+  McDstCut(const McDstCut &copy);
+
+  void excludePdg(int pdg);
+  /*
+    lo -- low edge of the range.
+    hi -- high edge of the range.
+  */
+  void setEta(float lo, float hi);
+  void setEtaLow(float val);
+  void setEtaHigh(float val);
+  void setPt(float lo, float hi);
+  void setPtLow(float val);
+  void setPtHigh(float val);
+
+  /*
+    Check parameters of the particle.
+  */
+  bool isGoodParticle(float eta, float pt, int pdg);
+
+private:
+  std::vector<int> pdgExclude;
+  /*
+    [0] -- low edge of the range.
+    [1] -- high edge of the range.
+  */
+  float etaCut[2];
+  float ptCut[2];
+
+  bool checkExcludePdg(int pdg);
+};
+
+#endif // #ifndef McDstCut_h

--- a/McDstLinkDef.h
+++ b/McDstLinkDef.h
@@ -10,6 +10,7 @@
 #pragma link C++ class McPIDConverter+;
 #pragma link C++ class McDst+;
 #pragma link C++ class McDstReader+;
+#pragma link C++ class McDstQA+;
 
 #pragma link C++ global gROOT;
 #pragma link C++ global gEnv;

--- a/McDstQA.cxx
+++ b/McDstQA.cxx
@@ -1,0 +1,218 @@
+#include "McDstQA.h"
+
+ClassImp(McDstQA);
+
+
+McDstQA::McDstQA(const char *input_file, const char *output_file)
+{
+  // Open output file.
+  ofile = new TFile(output_file, "RECREATE");
+  assert(ofile != nullptr);
+
+  cut = nullptr;
+
+  // Initialize histograms.
+  hImpactPar = new TH1F("hImpactPar", ";b [fm];#frac{dN_{events}}{db}",
+                        180, 0., 18.);
+  hRefMult05 = new TH1F("hRefMult05", ";RefMult_{|#eta| < 0.5};#frac{dN_{events}}{d(RefMult_{|#eta| < 0.5)}}",
+                        1000, 0., 1000.);
+  hRefMult10 = new TH1F("hRefMult10", ";RefMult_{|#eta| < 1.0};#frac{dN_{events}}{d(RefMult_{|#eta| < 1.0)}}",
+                        1000, 0., 1000.);
+  hNTracks = new TH1F("hNTracks", ";N_{tracks};#frac{dN_{events}}{dN_{tracks}}",
+                      1000, 0., 1000.);
+  hSph05 = new TH1F("hSph05", ";S_{#prep}^{|#eta| < 0.5};#frac{dN_{events}}{dS_{#prep}^{|#eta| < 0.5}}",
+                    100, 0., 1.0);
+  hSph10 = new TH1F("hSph10", ";S_{#prep}^{|#eta| < 1.0};#frac{dN_{events}}{dS_{#prep}^{|#eta| < 1.0}}",
+                    100, 0., 1.0);
+
+  hPx = new TH1F("hPx", ";p_{x} (GeV/c);#frac{dN_{tracks}}{dp_{x}}",
+                 512, -5., 5.);
+  hPy = new TH1F("hPy", ";p_{y} (GeV/c);#frac{dN_{tracks}}{dp_{y}}",
+                 512, -5., 5.);
+  hPz = new TH1F("hPz", ";p_{z} (GeV/c);#frac{dN_{tracks}}{dp_{z}}",
+                 512, -5., 5.);
+  hPdg = new TH1F("hPdg", ";pdg;#frac{dN_{tracks}}{d(pdg)}",
+                  9, 0, 9.);
+  TAxis *axis = hPdg->GetXaxis();
+  assert(axis != nullptr);
+  axis->SetBinLabel(1, "#pi^{-}");
+  axis->SetBinLabel(2, "#pi^{+}");
+  axis->SetBinLabel(3, "#pi^{0}");
+  axis->SetBinLabel(4, "K^{-}");
+  axis->SetBinLabel(5, "K^{+}");
+  axis->SetBinLabel(6, "p");
+  axis->SetBinLabel(7, "#bar{p}");
+  axis->SetBinLabel(8, "K^{0}_{S}");
+  axis->SetBinLabel(9, "K^{0}_{L}");
+
+  hMSqrVsP = new TH2F("hMSqrVsP", ";Q*p charge*(GeV/c);m^{2} (GeV^{2}/c^{4})",
+                      512, -5., 5.,
+                      256, -1, 3.);
+
+  // Create reader.
+  reader = new McDstReader(input_file);
+  assert(reader != nullptr);
+  reader->Init();
+
+  reader->SetStatus("*",0);
+  reader->SetStatus("Event",1);
+  reader->SetStatus("Particle",1);
+
+  // Check TChain and get number of entries.
+  assert(reader->chain() != nullptr);
+  nEvents = reader->chain()->GetEntries();
+  std::cout << "Number of events to read: " << nEvents << std::endl;
+}
+
+McDstQA::~McDstQA()
+{
+  ofile->cd();
+  ofile->Write();
+  delete ofile;
+  delete reader;
+}
+
+void McDstQA::setMcDstCut(McDstCut *ptr)
+{
+  cut = ptr;
+}
+
+
+void McDstQA::run(int nev)
+{
+  if (nev < 0)
+  {
+    nev = nEvents;
+  }
+  else if (nev > nEvents)
+  {
+    std::cout << "Warning: nev > nEvents => nev = nEvents\n";
+    nev = nEvents;
+  }
+
+  for (int iev = 0; iev < nev; ++iev)
+  {
+    int refmult05 = 0, refmult10 = 0;
+    int nTracks = 0;
+
+    if (!reader->loadEntry(iev))
+    {
+      std::cout << "mcReader->loadEntry(iEvent) == false. Skip event.\n";
+      continue;
+    }
+
+    McDst *dst = reader->mcDst();
+    if (dst == nullptr)
+    {
+      std::cout << "McDst == nullptr. Skip event.\n";
+      continue;
+    }
+    McEvent *event = dst->event();
+    if (event == nullptr)
+    {
+      std::cout << "McEvent == nullptr. Skip event.\n";
+      continue;
+    }
+
+    nTracks = dst->numberOfParticles();
+
+    // For transverse sphericity calculation.
+    TMatrixTSym<double> matrix05(2);
+    TMatrixTSym<double> matrix10(2);
+    matrix05.Zero();
+    matrix10.Zero();
+    double pTsum05 = 0.;
+    double pTsum10 = 0.;
+
+    for (int itr = 0; itr < nTracks; ++itr)
+    {
+      McParticle *track = dst->particle(itr);
+      int pdg = track->pdg();
+      const TLorentzVector &momentum = track->momentum();
+
+      // Track cut.
+      if (cut != nullptr &&
+          !cut->isGoodParticle(momentum.Eta(), momentum.Pt(), pdg))
+      {
+        continue;
+      }
+
+      // Calculate reference multiplicity and transverse sphericity.
+      if (track->charge() != 0 && momentum.Pt() > 0.1)
+      {
+        if (fabs(momentum.Eta()) <= 1.0)
+        {
+          ++refmult10;
+
+          (matrix10)(0, 0) += momentum.Px() * momentum.Px() / momentum.Pt();
+          (matrix10)(1, 1) += momentum.Py() * momentum.Py() / momentum.Pt();
+          (matrix10)(0, 1) += momentum.Px() * momentum.Py() / momentum.Pt();
+          (matrix10)(1, 0) += momentum.Px() * momentum.Py() / momentum.Pt();
+          pTsum10 += momentum.Pt();
+        }
+        if (fabs(momentum.Eta()) <= 0.5)
+        {
+          ++refmult05;
+
+          (matrix05)(0, 0) += momentum.Px() * momentum.Px() / momentum.Pt();
+      	  (matrix05)(1, 1) += momentum.Py() * momentum.Py() / momentum.Pt();
+      	  (matrix05)(0, 1) += momentum.Px() * momentum.Py() / momentum.Pt();
+      	  (matrix05)(1, 0) += momentum.Px() * momentum.Py() / momentum.Pt();
+      	  pTsum05 += momentum.Pt();
+        }
+      }
+
+      // M square vs Q*p. Px, Py, Pz.
+      hMSqrVsP->Fill(track->charge()*momentum.P(), momentum.M2());
+      hPx->Fill(momentum.Px());
+      hPy->Fill(momentum.Py());
+      hPz->Fill(momentum.Pz());
+
+      // PDG code.
+      switch (pdg)
+      {
+      case 211:
+        hPdg->Fill("#pi^{+}", 1.);
+        break;
+      case -211:
+        hPdg->Fill("#pi^{-}", 1.);
+        break;
+      case 2212:
+        hPdg->Fill("p", 1.);
+        break;
+      case -2212:
+        hPdg->Fill("#bar{p}", 1.);
+        break;
+      case 321:
+        hPdg->Fill("K^{+}", 1.);
+        break;
+      case -321:
+        hPdg->Fill("K^{-}", 1.);
+        break;
+      case 111:
+        hPdg->Fill("#pi^{0}", 1.);
+        break;
+      case 130:
+        hPdg->Fill("K^{0}_{L}", 1.);
+        break;
+      case 310:
+        hPdg->Fill("K^{0}_{S}", 1.);
+        break;
+      }
+    }
+    // Calculate eigen values for matrices.
+    matrix05 *= 1./pTsum05;
+    matrix10 *= 1./pTsum10;
+    TMatrixDSymEigen eigenEstimator05(matrix05);
+    TMatrixDSymEigen eigenEstimator10(matrix10);
+    TVectorD eigen05 = eigenEstimator05.GetEigenValues();
+    TVectorD eigen10 = eigenEstimator10.GetEigenValues();
+
+    hSph05->Fill(2. * eigen05.Min() / ( eigen05[0] + eigen05[1] ));
+    hSph10->Fill(2. * eigen10.Min() / ( eigen10[0] + eigen10[1] ));
+    hImpactPar->Fill(event->impact());
+    hRefMult05->Fill(refmult05);
+    hRefMult10->Fill(refmult10);
+    hNTracks->Fill(nTracks);
+  }
+}

--- a/McDstQA.cxx
+++ b/McDstQA.cxx
@@ -160,7 +160,7 @@ void McDstQA::run(int nev)
 
       // Track cut.
       if (cut != nullptr &&
-          !cut->isGoodParticle(momentum.Eta(), momentum.Pt(), pdg))
+          !cut->isGoodParticle(momentum, pdg))
       {
         continue;
       }

--- a/McDstQA.cxx
+++ b/McDstQA.cxx
@@ -31,6 +31,8 @@ McDstQA::McDstQA(const char *input_file, const char *output_file)
                  512, -5., 5.);
   hPz = new TH1F("hPz", ";p_{z} (GeV/c);#frac{dN_{tracks}}{dp_{z}}",
                  512, -5., 5.);
+  hEta = new TH1F("hEta", ";#eta;#frac{dN_{tracks}}{d#eta}",
+                  2000, -10., 10.);
   hPdg = new TH1F("hPdg", ";pdg;#frac{dN_{tracks}}{d(pdg)}",
                   9, 0, 9.);
   TAxis *axis = hPdg->GetXaxis();
@@ -168,7 +170,7 @@ void McDstQA::run(int nev)
       hPx->Fill(momentum.Px());
       hPy->Fill(momentum.Py());
       hPz->Fill(momentum.Pz());
-
+      hEta->Fill(momentum.Eta());
       // PDG code.
       switch (pdg)
       {

--- a/McDstQA.cxx
+++ b/McDstQA.cxx
@@ -130,13 +130,6 @@ void McDstQA::run(int nev)
       int pdg = track->pdg();
       const TLorentzVector &momentum = track->momentum();
 
-      // Track cut.
-      if (cut != nullptr &&
-          !cut->isGoodParticle(momentum.Eta(), momentum.Pt(), pdg))
-      {
-        continue;
-      }
-
       // Calculate reference multiplicity and transverse sphericity.
       if (track->charge() != 0 && momentum.Pt() > 0.1)
       {
@@ -144,6 +137,7 @@ void McDstQA::run(int nev)
         {
           ++refmult10;
 
+          // Transverse sphericity calculation.
           (matrix10)(0, 0) += momentum.Px() * momentum.Px() / momentum.Pt();
           (matrix10)(1, 1) += momentum.Py() * momentum.Py() / momentum.Pt();
           (matrix10)(0, 1) += momentum.Px() * momentum.Py() / momentum.Pt();
@@ -160,6 +154,13 @@ void McDstQA::run(int nev)
       	  (matrix05)(1, 0) += momentum.Px() * momentum.Py() / momentum.Pt();
       	  pTsum05 += momentum.Pt();
         }
+      }
+
+      // Track cut.
+      if (cut != nullptr &&
+          !cut->isGoodParticle(momentum.Eta(), momentum.Pt(), pdg))
+      {
+        continue;
       }
 
       // M square vs Q*p. Px, Py, Pz.

--- a/McDstQA.h
+++ b/McDstQA.h
@@ -46,7 +46,7 @@ public:
   TH1F *hRefMult05, *hRefMult10;
   TH1F *hNTracks;
   TH1F *hSph05, *hSph10; // Transverse sphericity.
-
+  TH1F *hEta;
   /*
     Track QA histograms.
   */

--- a/McDstQA.h
+++ b/McDstQA.h
@@ -1,0 +1,67 @@
+/*
+  Copyright (c) 2020 Eugenia Khyzhniak <eugenia.sh.el@gmail.com>, Nikita (arei) Ermakov <coffe92@gmail.com>
+  SPDX-License-Identifier: MIT
+*/
+
+#ifndef MCDSTQA_H
+#define MCDSTQA_H
+
+// C/C++ headers.
+#include <iostream>
+#include <string>
+#include <map>
+#include <assert.h>
+
+// ROOT headers.
+#include "TObject.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TMath.h"
+#include "TClonesArray.h"
+#include "TLorentzVector.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TMatrixDSymEigen.h"
+#include "TMatrixTLazy.h"
+
+// McDst headers.
+#include "McDstReader.h"
+#include "McDstCut.h"
+#include "McParticle.h"
+#include "McEvent.h"
+
+class McDstQA : public TObject
+{
+public:
+  McDstQA(const char *input_file, const char *output_file);
+  ~McDstQA();
+
+  void setMcDstCut(McDstCut *ptr);
+
+  /*
+    Event QA histograms.  We are expose these histograms to make it
+    possible to change limits/binning before `::run()`.
+  */
+  TH1F *hImpactPar;
+  TH1F *hRefMult05, *hRefMult10;
+  TH1F *hNTracks;
+  TH1F *hSph05, *hSph10; // Transverse sphericity.
+
+  /*
+    Track QA histograms.
+  */
+  TH1F *hPx, *hPy, *hPz;
+  TH1F *hPdg;
+  TH2F *hMSqrVsP;
+
+  void run(int nev = -1);
+private:
+  McDstReader *reader;
+  TFile *ofile;
+  McDstCut *cut;
+  int nEvents;
+
+  ClassDef(McDstQA, 1);
+};
+
+#endif // #ifndef MCDSTQA_H

--- a/hijing2mc.cpp
+++ b/hijing2mc.cpp
@@ -1,0 +1,267 @@
+/**
+ * urqmd2mc reads UrQMD events from the ftn13 or ftn14 ascii files and
+ * converts them to the UniGen format and saves on a root file.
+ *
+ * ftn14 contains snapshots at given times (event steps). The event steps
+ * are converted to separate events.
+ *
+ * ftn13 contains the final snapshot and the freeze-out coordinates.
+ * The freeze-out coordinates are used. The final snapshot coordinates
+ * are discarded.
+ */
+
+// C++ headers
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <string>
+#include <map>
+
+// ROOT headers
+#include "TObject.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TString.h"
+#include "TBranch.h"
+#include "TMath.h"
+#include "TClonesArray.h"
+
+// McDst headers
+#include "McRun.h"
+#include "McEvent.h"
+#include "McParticle.h"
+#include "McPIDConverter.h"
+#include "McArrays.h"
+
+
+//StarGenEvent headers
+
+#include "../EVENT/StarGenAAEvent.h"
+#include "../EVENT/StarGenEvent.h"
+#include "../EVENT/StarGenParticle.h"
+#include "../EVENT/StarGenStats.h"
+
+
+using namespace std;
+
+TClonesArray *arrays[McArrays::NAllMcArrays];
+
+//_________________
+void bomb(const char *myst) {
+  std::cerr << "Error: " << myst << ", bombing" << std::endl;
+  exit(-1);
+}
+
+//_________________
+std::string newName(char* origName) {
+  std::string fname(origName);
+  std::string key1 = ".root";
+  std::size_t found1 = fname.rfind(key1);
+  if ( found1 != std::string::npos ) {
+    fname.replace(found1, key1.length(), ".mcDst.root");
+  }
+  else {
+    bomb("Wrong input data format (not .root)");
+  }
+
+  return fname;
+}
+
+
+//_________________
+int main(int argc, char *argv[]) {
+
+  //  ifstream in;
+  char *inpfile;
+  char c;
+  int nevents;
+  string dust;
+  bool debug = false;
+
+  McRun *run = nullptr;
+
+  string version, comment;
+  int filetype, eos, aproj, zproj, atarg, ztarg, nr;
+  double beta, b, bmin, bmax, sigma, elab, plab, sqrts, time, dtime;
+
+  if (argc != 3) {
+    std::cout << "usage:   " << argv[0] << " inputfile nevents\n";
+    std::cout << "example: " << argv[0] << " inputfile.root 10 \n"
+	      << "This will create inputfile.mcDst.root\n";
+    exit(0);
+  }
+
+  inpfile = argv[1];
+  nevents = atoi(argv[2]);
+
+  int nout=0;
+
+  // Check that filename contains .f13 or .f14
+  TString oFileName( newName( argv[1] ) );
+
+  
+  /*  in.open(inpfile);
+      if ( in.fail() ) {
+      bomb("cannot open input file");
+      }
+  */
+
+  TFile *fi = TFile::Open(oFileName.Data(), "RECREATE", "HIJING");
+
+
+
+  fi->SetCompressionLevel(9);
+  int bufsize = 65536 * 4;
+  int split = 99;
+
+  // Create and set out TTree
+  McEvent::Class()->IgnoreTObjectStreamer();
+  McParticle::Class()->IgnoreTObjectStreamer();
+  McRun::Class()->IgnoreTObjectStreamer();
+
+  TTree *tr = new TTree("McDst", "Hijing tree", split);
+  tr->SetAutoSave(1000000);
+  for (unsigned int i = 0; i < McArrays::NAllMcArrays; i++) {
+    // Create arrayss
+    arrays[i] = new TClonesArray( McArrays::mcArrayTypes[i], McArrays::mcArraySizes[i] );
+    // Set branch
+    tr->Branch(McArrays::mcArrayNames[i], &arrays[i], bufsize / 4, split);
+  }
+
+  // Try to open file
+  TFile *inFile = new TFile(inpfile,"READ");
+
+  //Getting a tree
+  TTree *inTree = nullptr;
+  inFile->GetObject("genevents",inTree);
+  StarGenEvent *evHij = nullptr;
+  StarGenParticle *parHij = nullptr;
+  StarGenAAEvent *evInfoHij = nullptr;
+  StarGenStats *statHij = nullptr;
+  inFile->GetObject("stats",statHij);
+  sigma = 0;//statHij->sigmaGen;
+  inTree->SetBranchAddress("primaryEvent", &evHij);
+  inTree->SetBranchAddress("Hijing", &evInfoHij);
+
+
+
+  
+  // How oftep to print info
+  const int bunch = 100;
+
+  int events_processed=0;
+  
+  // Start event loop
+
+  if (nevents > inTree->GetEntriesFast()) {
+    std::cout<<"Too much nevents. Switch to"<<inTree->GetEntriesFast()<<std::endl;
+    nevents = inTree->GetEntriesFast();
+  }//if (nevents > inTree->GetEntriesFast())
+
+  for (int n=0; n<nevents; n++) {
+
+    for (unsigned int i = 0; i < McArrays::NAllMcArrays; i++) {
+      // Create arrayss
+      arrays[i]->Clear();
+    }
+
+    inTree->GetEntry(n);
+
+    McEvent *ev = new ( ( *(arrays[McArrays::Event]) )[arrays[McArrays::Event]->GetEntries()]) McEvent();
+
+    ev->setEventNr(evInfoHij->GetEventNumber());
+    ev->setB(evInfoHij->impactParameter);
+    ev->setPhi(evInfoHij->reactionPlane);
+    ev->setNes(0);
+
+    sqrts = evInfoHij->GetRootS();
+    
+    //    std::cout<<evHij->GetNumberOfParticles()<<" "<<evInfoHij->numberOfParticipantNeutrons[0]+evInfoHij->numberOfParticipantNeutrons[1]+evInfoHij->numberOfParticipantProtons[0]+evInfoHij->numberOfParticipantProtons[1]<<std::endl;
+
+
+    if (evHij->GetNumberOfParticles() < 2) continue;
+
+
+    events_processed++;
+	
+    for ( int iTr = 1; iTr < evHij->GetNumberOfParticles(); iTr++) { //BEWARE: Numeration at StarGenEvent is specific: it starts with 1, but counts from 0 >.<
+      parHij = (*evHij)[iTr];
+
+      double t, x, y, z, e, px, py, pz;
+      int ityp, iso3, ichg, status, parent, parent_decay, mate;
+      int decay, child[2];
+
+      t = parHij->GetTof();
+      x = parHij->GetVx();
+      y = parHij->GetVy();
+      z = parHij->GetVz();
+
+      e = parHij->GetEnergy();
+
+
+      px = parHij->GetPx();
+      py = parHij->GetPy();
+      pz = parHij->GetPz();
+
+      ityp = parHij->GetId();
+      status = parHij->GetStatus();
+
+      
+      if ( parHij->GetLastMother() == -1 ) {
+	parent = parHij->GetFirstMother();
+      } else {
+	parent = parHij->GetLastMother();
+      }//      if ( parHij->GetLastMother() == -1 ) {
+
+      parent_decay = 0;
+      mate = 0;
+      decay = 0;
+      child[0] = parHij->GetFirstDaughter();
+      child[1] = parHij->GetLastDaughter();
+      if (parHij->GetFirstDaughter() == -1 && parHij->GetLastDaughter() == -1) decay = -1;      
+
+      
+      new ( ( *(arrays[McArrays::Particle]) )[arrays[McArrays::Particle]->GetEntries()])
+	McParticle( iTr-1, ityp, status, parent,
+		    parent_decay, mate-1, decay, child,
+		    px, py, pz, e, x, y, z, t );
+      McParticle *particle = (McParticle*)arrays[McArrays::Particle]->At(iTr-1);      
+      //      std::cout<<particle->pdg()<<std::endl;
+      
+    }//    for ( int iTr = 0; iTr < evHij->GetNumberOfParticles(); iTr++)
+    nout += tr->Fill();    
+  } // for (int n=0; n<nevents; n++)
+
+  inFile->Close();
+  fi->cd();
+  std::cout << events_processed << " events processed\n";
+
+  // create the run object
+
+  std::string generator = "Hijing";
+  generator.append(version);
+  double m = 0.938271998;
+  double ecm = sqrts/2; // energy per nucleon in cm
+  double pcm = sqrt(ecm*ecm-m*m); // momentum per nucleon in cm
+  double gamma = 0;//1.0/sqrt(1-beta*beta);
+  double pproj = 0;//gamma*(+pcm-beta*ecm);
+  double ptarg = 0;//gamma*(-pcm-beta*ecm);
+  bmin = 0;
+  bmax = 0;
+  aproj = 0;
+  zproj = 0;
+
+  atarg = 0;
+  ztarg = 0;
+  run = new McRun( generator.data(), comment.data(),
+		   aproj, zproj, pproj,
+		   atarg, ztarg, ptarg,
+		   bmin, bmax, -1, 0, 0, sigma, events_processed);
+  run->Write();
+  fi->Write();
+  fi->Close();
+  std::cout << "Total bytes were written: " << nout << std::endl;
+
+  
+  return 0;
+}

--- a/hijing2mc.cpp
+++ b/hijing2mc.cpp
@@ -10,13 +10,6 @@
  * are discarded.
  */
 
-/*
-  WARNING: This macro SHOULD NOT be compiled with the `cons' at BNL
-  clusters.  The `cons' will add -D__ROOT_ to the `g++' so in the case
-  of -D__ROOT__ this source file will be expanded to zero.
-*/
-#ifndef __ROOT__
-
 // C++ headers
 #include <iostream>
 #include <fstream>
@@ -272,5 +265,3 @@ int main(int argc, char *argv[]) {
   
   return 0;
 }
-
-#endif // #ifndef __ROOT__

--- a/hijing2mc.cpp
+++ b/hijing2mc.cpp
@@ -10,6 +10,13 @@
  * are discarded.
  */
 
+/*
+  WARNING: This macro SHOULD NOT be compiled with the `cons' at BNL
+  clusters.  The `cons' will add -D__ROOT_ to the `g++' so in the case
+  of -D__ROOT__ this source file will be expanded to zero.
+*/
+#ifndef __ROOT__
+
 // C++ headers
 #include <iostream>
 #include <fstream>
@@ -265,3 +272,5 @@ int main(int argc, char *argv[]) {
   
   return 0;
 }
+
+#endif // #ifndef __ROOT__

--- a/macros/mcdstqa.C
+++ b/macros/mcdstqa.C
@@ -1,0 +1,28 @@
+/*
+  Copyright (c) 2020 Eugenia Khyzhniak <eugenia.sh.el@gmail.com>, Nikita (arei) Ermakov <coffe92@gmail.com>
+  SPDX-License-Identifier: MIT
+
+  This is a simple example of using McDstQA class.
+*/
+
+#include "../McDstQA.h"
+
+void mcdstqa(const char *ifile = "../test.mcDst.root", const char *ofile = "../qa_mcdst.root")
+{
+#if defined(ROOT_VERSION_CODE) && defined(ROOT_VERSION)
+#  if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0) // ROOT 5.
+  gSystem->Load("../libMcDst.so");
+#  else // ROOT 6.
+  R__LOAD_LIBRARY(../libMcDst)
+#  endif
+#else
+#  error "Could not find ROOT_VERSION_CODE or ROOT_VERSION macros."
+#endif
+
+  McDstQA qa(ifile, ofile);
+  McDstCut cut;
+  cut.excludePdg(-211); // exclude #pi^{-}. Just for example.
+  qa.setMcDstCut(&cut);
+
+  qa.run();
+}

--- a/pythia8gen-simple-hbt.cfg
+++ b/pythia8gen-simple-hbt.cfg
@@ -1,0 +1,65 @@
+# This is a simple sample configuration file for Pythia 8.
+# The format of the file is straightforward [1]:
+# * Each line either a variable and its value or a comment.
+# * Equal sign is optional.
+# * Variable begins with a letter for settings and a digit for particle data.
+# * !,#,$,% etc is for comment.
+# * Variable name is case-insensitive.
+#
+# For more configuration options please refer to the [2].
+#
+# Be aware that Random:setSeed is always on (hardcoded) and one MUST
+# choose either to set seed manually (--rnd) or it will be set
+# automatically.  Also there is no point to set Random:seed option
+# explicitly in the configuration file or command line arguments
+# because it will be overridden at the runtime.
+#
+# [1] arXiv:1410:3012
+# [2] http://home.thep.lu.se/~torbjorn/pythia82html/Welcome.html
+
+Main:numberOfEvents = 100000
+
+Beams:idA = 2212
+Beams:idB = 2212
+Beams:eCM = 200.
+
+# HBT
+HadronLevel:BoseEinstein = on
+
+# Minimum bias is inelastic, nondiffractive events.
+SoftQCD:nonDiffractive = on
+#SoftQCD:inelastic = off
+#SoftQCD:elastic = off
+#SoftQCD:SoftQCD:singleDiffractive = off
+#SoftQCD:doubleDiffractive = off
+#SoftQCD:centralDiffractive = off
+
+# HardQCD processes.
+#HardQCD:gg2gg = off
+#HardQCD:gg2qqbar = off
+#HardQCD:qg2qg = off
+#HardQCD:qq2qq = off
+#HardQCD:qqbar2gg = off
+#HardQCD:qqbar2qqbarNew = off
+#HardQCD:nQuarkNew = off
+
+# Hard QCD processes: heavy-flavour subset.
+#HardQCD:gg2ccbar = off
+#HardQCD:qqbar2ccbar = off
+#HardQCD:hardccbar = off
+#HardQCD:gg2bbbar = off
+#HardQCD:qqbar2bbbar = off
+#HardQCD:hardbbbar = off
+
+# Hard QCD three-parton processes.
+#HardQCD:3parton = off
+#HardQCD:gg2ggg = off
+#HardQCD:qqbar2ggg = off
+#HardQCD:qg2qgg = off
+#HardQCD:qq2qqgDiff = off
+#HardQCD:qq2qqgSame = off
+#HardQCD:qqbar2qqbargDiff = off
+#HardQCD:qqbar2qqbargSame = off
+#HardQCD:gg2qqbarg = off
+#HardQCD:qg2qqqbarDiff = off
+#HardQCD:qg2qqqbarSame = off

--- a/pythia8gen-simple.cfg
+++ b/pythia8gen-simple.cfg
@@ -1,0 +1,62 @@
+# This is a simple sample configuration file for Pythia 8.
+# The format of the file is straightforward [1]:
+# * Each line either a variable and its value or a comment.
+# * Equal sign is optional.
+# * Variable begins with a letter for settings and a digit for particle data.
+# * !,#,$,% etc is for comment.
+# * Variable name is case-insensitive.
+#
+# For more configuration options please refer to the [2].
+#
+# Be aware that Random:setSeed is always on (hardcoded) and one MUST
+# choose either to set seed manually (--rnd) or it will be set
+# automatically.  Also there is no point to set Random:seed option
+# explicitly in the configuration file or command line arguments
+# because it will be overridden at the runtime.
+#
+# [1] arXiv:1410:3012
+# [2] http://home.thep.lu.se/~torbjorn/pythia82html/Welcome.html
+
+Main:numberOfEvents = 100
+
+Beams:idA = 1000020040
+Beams:idB = 1000791970
+Beams:eCM = 200.
+
+# Minimum bias is inelastic, nondiffractive events.
+SoftQCD:nonDiffractive = on
+#SoftQCD:inelastic = off
+#SoftQCD:elastic = off
+#SoftQCD:SoftQCD:singleDiffractive = off
+#SoftQCD:doubleDiffractive = off
+#SoftQCD:centralDiffractive = off
+
+# HardQCD processes.
+#HardQCD:gg2gg = off
+#HardQCD:gg2qqbar = off
+#HardQCD:qg2qg = off
+#HardQCD:qq2qq = off
+#HardQCD:qqbar2gg = off
+#HardQCD:qqbar2qqbarNew = off
+#HardQCD:nQuarkNew = off
+
+# Hard QCD processes: heavy-flavour subset.
+#HardQCD:gg2ccbar = off
+#HardQCD:qqbar2ccbar = off
+#HardQCD:hardccbar = off
+#HardQCD:gg2bbbar = off
+#HardQCD:qqbar2bbbar = off
+#HardQCD:hardbbbar = off
+
+# Hard QCD three-parton processes.
+#HardQCD:3parton = off
+#HardQCD:gg2ggg = off
+#HardQCD:qqbar2ggg = off
+#HardQCD:qg2qgg = off
+#HardQCD:qq2qqgDiff = off
+#HardQCD:qq2qqgSame = off
+#HardQCD:qqbar2qqbargDiff = off
+#HardQCD:qqbar2qqbargSame = off
+#HardQCD:gg2qqbarg = off
+#HardQCD:qg2qqqbarDiff = off
+#HardQCD:qg2qqqbarSame = off

--- a/pythia8gen-simple.cfg
+++ b/pythia8gen-simple.cfg
@@ -17,11 +17,13 @@
 # [1] arXiv:1410:3012
 # [2] http://home.thep.lu.se/~torbjorn/pythia82html/Welcome.html
 
-Main:numberOfEvents = 100
+Main:numberOfEvents = 1
 
 Beams:idA = 1000020040
 Beams:idB = 1000791970
 Beams:eCM = 200.
+
+Print:quiet = on
 
 # Minimum bias is inelastic, nondiffractive events.
 SoftQCD:nonDiffractive = on
@@ -32,6 +34,8 @@ SoftQCD:nonDiffractive = on
 #SoftQCD:centralDiffractive = off
 
 # HardQCD processes.
+HardQCD:all = on
+PhaseSpace:pTHatMin = 2.0
 #HardQCD:gg2gg = off
 #HardQCD:gg2qqbar = off
 #HardQCD:qg2qg = off

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -3,6 +3,13 @@
   SPDX-License-Identifier: MIT
 */
 
+/*
+  WARNING: This macro SHOULD NOT be compiled with the `cons' at BNL
+  clusters.  The `cons' will add -D__ROOT_ to the `g++' so in the case
+  of -D__ROOT__ this source file will be expanded to zero.
+*/
+#ifndef __ROOT__
+
 // getopt.
 #include <unistd.h>
 #include <getopt.h>
@@ -454,3 +461,5 @@ main(int argc, char *argv[])
   outFile->Close();
   return EXIT_SUCCESS;
 }
+
+#endif // #ifndef __ROOT__

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -442,7 +442,7 @@ main(int argc, char *argv[])
       float t = ev[itrk].tProd()*1e-12; // decayed particle.
 
       // Check particle cut.
-      if (!cut.isGoodParticle(v.Pt(), v.PseudoRapidity(), pdg))
+      if (!cut.isGoodParticle(v, pdg))
       {
         continue;
       }

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -67,7 +67,7 @@ struct option longopts[] =
   { .name = "rnd", .has_arg = 1, .flag = 0, .val = 'r' },
   { .name = "compression-level", .has_arg = 1, .flag = 0, .val = 0xFF01 },
   { .name = "compression-algo", .has_arg = 1, .flag = 0, .val = 0xFF02 },
-  { .name = "only-final", .has_arg = 0, .flag = 0, .val = 0xFF03 },
+  { .name = "all-particles", .has_arg = 0, .flag = 0, .val = 0xFF03 },
   { .name = "xmldoc-dir", .has_arg = 1, .flag = 0, .val = 0xFF04 },
   { 0, 0, 0, 0 }
 };

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -292,6 +292,10 @@ main(int argc, char *argv[])
       int mate = 0;
       int child[2] = {0};
 
+      // Skip beam particles.
+      if (abs(status) < 19)
+        continue;
+
       // Optionally do skip not final particles.
       if (status < 0)
       {

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019 Nikita (arei) Ermakov <coffe92@gmail.com>
+  Copyright (c) 2019-2020 Nikita (arei) Ermakov <coffe92@gmail.com>
   SPDX-License-Identifier: MIT
 */
 

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -220,16 +220,16 @@ main(int argc, char *argv[])
       xmldoc = optarg;
       break;
     case 0xFF05:
-      cut.setPtLow(std::stoi(optarg));
+      cut.setPtLow(std::stof(optarg));
       break;
     case 0xFF06:
-      cut.setPtHigh(std::stoi(optarg));
+      cut.setPtHigh(std::stof(optarg));
       break;
     case 0xFF07:
-      cut.setEtaLow(std::stoi(optarg));
+      cut.setEtaLow(std::stof(optarg));
       break;
     case 0xFF08:
-      cut.setEtaHigh(std::stoi(optarg));
+      cut.setEtaHigh(std::stof(optarg));
       break;
     case 0xFF09:
       cut.excludePdg(std::stoi(optarg));

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -41,6 +41,7 @@
 
 // Pythia 8 headers.
 #include "Pythia8/Pythia.h"
+#include "Pythia8/HeavyIons.h"
 
 /*
   Emit error message and exit. Args:
@@ -155,6 +156,8 @@ main(int argc, char *argv[])
   const uint32_t lz4 = 8008704; // hash4("lz4")
   // Preselection cut class.
   McDstCut cut;
+  // Heavy ion collision class.
+  Pythia8::Angantyr *hion = nullptr;
 
   // Parse command line arguments.
   if (argc <= 1)
@@ -264,6 +267,7 @@ main(int argc, char *argv[])
 
   // Setting up Pythia 8.
   pythia.init();
+  hion = (Pythia8::Angantyr *)pythia.getHeavyIonsPtr();
 
   // Setting up McDst.
   outFile = new TFile(ofile, "RECREATE");
@@ -302,7 +306,7 @@ main(int argc, char *argv[])
     TClonesArray *mcEvCol = mcArrays[McArrays::Event];
     McEvent *mcEv = new ((*mcEvCol)[mcEvCol->GetEntries()]) McEvent();
     mcEv->setEventNr(iev);
-    mcEv->setB(0.0); // Always 0 in Pythia 8 without MPI.
+    mcEv->setB(hion->hiinfo.b());
     mcEv->setPhi(0.0); // 0 in Pythia 8.
     mcEv->setNes(0);
     mcEv->setComment(0);

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -1,0 +1,386 @@
+/*
+  Copyright (c) 2019 Nikita (arei) Ermakov <coffe92@gmail.com>
+  SPDX-License-Identifier: MIT
+*/
+
+// getopt.
+#include <unistd.h>
+#include <getopt.h>
+
+// srand/rand
+#include <stdlib.h>
+
+#include <assert.h>
+
+// C++ headers.
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <string>
+#include <map>
+#include <cstdint>
+
+// ROOT headers.
+#include "TObject.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TString.h"
+#include "TBranch.h"
+#include "TMath.h"
+#include "TClonesArray.h"
+#include "Compression.h"
+
+// McDst headers.
+#include "McRun.h"
+#include "McEvent.h"
+#include "McParticle.h"
+#include "McPIDConverter.h"
+#include "McArrays.h"
+
+// Pythia 8 headers.
+#include "Pythia8/Pythia.h"
+
+/*
+  Emit error message and exit. Args:
+  * doexit - if 0 then do not exit, else exit from a program.
+  * format - printf-like format string.
+  * ... - arguments for format string.
+  There is no need to add a new line character explicitly at the end of the
+  format string.
+*/
+#define ERR(doexit, format, ...)                                        \
+  { fprintf(stderr, "pythia8gen.cpp:%d / errno=%d / " format "\n", __LINE__, errno, ##__VA_ARGS__); \
+    if (doexit) exit(EXIT_FAILURE); }                                   \
+
+#define PROGNAME "pythia8gen"
+#define VERSION "1.0"
+#define OFILE_DEFAULT "out_pythia8.root"
+
+// Options for getopt.
+struct option longopts[] =
+{
+  { .name = "help", .has_arg = 0, .flag = 0, .val = 'h' },
+  { .name = "pythia-option", .has_arg = 1, .flag = 0, .val = 's' },
+  { .name = "ifile", .has_arg = 1, .flag = 0, .val = 'i' },
+  { .name = "ofile", .has_arg = 1, .flag = 0, .val = 'o' },
+  { .name = "rnd", .has_arg = 1, .flag = 0, .val = 'r' },
+  { .name = "compression-level", .has_arg = 1, .flag = 0, .val = 0xFF01 },
+  { .name = "compression-algo", .has_arg = 1, .flag = 0, .val = 0xFF02 },
+  { .name = "only-final", .has_arg = 0, .flag = 0, .val = 0xFF03 },
+  { 0, 0, 0, 0 }
+};
+
+// Output help string.
+void
+help_me()
+{
+  const char *hstr =                                                    \
+    PROGNAME " v" VERSION " Pythia 8 McDst generator\n"                 \
+    "Usage: " PROGNAME " [Options]\n"                                   \
+    "Options:\n\
+    -h, --help                      help\n\
+    -s, --pythia-option <OPTION>    pass an option to Pythia8\n\
+    -i, --ifile <FILE NAME>         input Pythia8 configuration file\n\
+    -o, --ofile <FILE NAME>         output file (default: " OFILE_DEFAULT ")\n\
+    -r, --rnd <SEED>                override random seed\n\
+    --compression-level <LEVEL>     Set compression level to <LEVEL>.\n\
+                                    Valid levels are from 1 (low) 9 (high).\n\
+    --compression-algo <ALGORITHM>  Set compression algorithm to <ALGORITHM>\n\
+                                    Possible values are zlib, lz4 (only for ROOT > 6), lzma\n\
+    --all-particles                 Save decayed/branched/fragmented/... particles too\n";
+
+  std::cout << hstr;
+  exit(EXIT_SUCCESS);
+}
+
+/*
+  Simple hash function to compare 4 bytes char arrays.  If char array
+  are more than 4 bytes long it could results in hash collisions.
+*/
+uint32_t
+hash4(char *s)
+{
+  uint32_t hash = 0;
+
+  while (*s++)
+    hash = (hash << 8) | (uint32_t)*s;
+  return hash;
+}
+
+int
+main(int argc, char *argv[])
+{
+  int onlyFinal = 1;
+  const char optstring[] = "hs:i:o:n:"; // This string must be sync with a struct option array.
+  int opt, nev;
+  char *rnd = 0;
+  char *ifile = 0;
+  char *ofile = OFILE_DEFAULT; // FIXME: ISO C++ forbids converting a string constant to ‘char*’
+  TFile *outFile = 0;
+  TTree *tree = 0;
+#if defined(ROOT_VERSION_CODE) && defined(ROOT_VERSION)
+#  if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0) // ROOT 5.
+  int ofileCompLevel = 7;
+#  else // ROOT 6.
+  int ofileCompLevel = ROOT::RCompressionSetting::ELevel::kDefaultLZMA;
+#  endif
+#else
+#  error "Could not find ROOT_VERSION_CODE or ROOT_VERSION macros."
+#endif
+  int ofileCompAlgo = ROOT::kLZMA; // Use LZMA by default.
+  int treeAutoSave = -(4 << 20); /* Do auto save each 4 MB == 4^20 Bytes.
+                                    Minus stands for bytes limit rather than number of entries. */
+  TClonesArray *mcArrays[McArrays::NAllMcArrays];
+  Pythia8::Pythia pythia("../share/Pythia8/xmldoc" /* see Pythia8/Pythia.h */, false);
+  // Precalculated hashes.
+  const uint32_t lzma = 2053988608; // hash4("lzma")
+  const uint32_t zlib = 1818845696; // hash4("zlib")
+  const uint32_t lz4 = 8008704; // hash4("lz4")
+
+  // Parse command line arguments.
+  if (argc <= 1)
+    ERR(1, "For the help message try: %s --help", PROGNAME);
+
+  while ((opt = getopt_long(argc, argv, optstring, longopts, 0)) != -1)
+  {
+    switch (opt)
+    {
+    case 'h':
+      help_me();
+      break;
+    case 's':
+      pythia.readString(optarg);
+      break;
+    case 'i':
+      ifile = optarg;
+      pythia.readFile(ifile);
+      break;
+    case 'o':
+      ofile = optarg;
+      break;
+    case 'r':
+      rnd = optarg;
+      break;
+    case 0xFF01:
+      ofileCompLevel = std::stoi(optarg);
+      std::cout << "ofileCompLevel = " << ofileCompLevel << std::endl;
+      break;
+    case 0xFF02:
+      switch (hash4(optarg))
+      {
+      case lzma:
+        ofileCompLevel = ROOT::kLZMA;
+        break;
+      case zlib:
+        ofileCompLevel = ROOT::kZLIB;
+        break;
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0) // ROOT 5.
+      case lz4:
+        ofileCompLevel = ROOT::kLZ4;
+        break;
+#endif
+      default:
+        std::cout << "Warning: there is no support for " << optarg << " compression algorithm"
+                  << "\nWarning: fallback to the lzma!\n";
+        ofileCompLevel = ROOT::kLZMA;
+      }
+      break;
+    case 0xFF03:
+      onlyFinal = 0;
+      break;
+    default:
+      ERR(1, "Wrong option: %c", (char)opt);
+    }
+  }
+
+  // Initialize random seed.
+  pythia.readString("Random:setSeed = on");
+  std::string sseed = "Random:seed = ";
+  if (rnd)
+  { // Set random seed manually.
+    sseed += rnd;
+  }
+  else
+  { // Get random seed from time.
+    srand(time(NULL));
+    int seed = int(((float)rand()/RAND_MAX)*900000000.); // 900000000 is a maximum possible seed in Pythia 8.
+    sseed += std::to_string(seed);
+  }
+  pythia.readString(sseed);
+
+  // Setting up Pythia 8.
+  pythia.init();
+
+  // Setting up McDst.
+  outFile = new TFile(ofile, "RECREATE");
+  if (!outFile)
+    ERR(1, "cannot open output file");
+  outFile->SetCompressionLevel(ofileCompLevel);
+  outFile->SetCompressionLevel(ofileCompAlgo);
+  McEvent::Class()->IgnoreTObjectStreamer();
+  McParticle::Class()->IgnoreTObjectStreamer();
+  McRun::Class()->IgnoreTObjectStreamer();
+  tree = new TTree("McDst", "Pythia 8 tree");
+  if (!tree)
+  {
+    outFile->Close();
+    ERR(1, "cannot create McDst TTree");
+  }
+  tree->SetAutoSave(treeAutoSave);
+  for (int i = 0; i < McArrays::NAllMcArrays; ++i)
+  { // Create arrays.
+    mcArrays[i] = new TClonesArray(McArrays::mcArrayTypes[i], McArrays::mcArraySizes[i]);
+    // Set branch.
+    tree->Branch(McArrays::mcArrayNames[i], &mcArrays[i]);
+  }
+
+  // Main loop.
+  nev = pythia.mode("Main:numberOfEvents");
+  for (int iev = 0; iev < nev; ++iev)
+  {
+    // Generate event.
+    pythia.next();
+    // Clear all arrays.
+    for (int i = 0; i < McArrays::NAllMcArrays; mcArrays[i++]->Clear());
+    // Get event.
+    const Pythia8::Event &ev = pythia.event;
+    // Set McEvent. FIXME: check nullptr.
+    TClonesArray *mcEvCol = mcArrays[McArrays::Event];
+    McEvent *mcEv = new ((*mcEvCol)[mcEvCol->GetEntries()]) McEvent();
+    mcEv->setEventNr(iev);
+    mcEv->setB(0.0); // Always 0 in Pythia 8 without MPI.
+    mcEv->setPhi(0.0); // 0 in Pythia 8.
+    mcEv->setNes(0);
+    mcEv->setComment(0);
+    mcEv->setStepNr(0);
+    mcEv->setStepT(0);
+
+    // Set McTrack.
+    int ntrk = ev.size();
+    for (int itrk = 0; itrk < ntrk; ++itrk)
+    {
+      int status = ev[itrk].status();
+      int decay = -1; /* -1 means not decayed, see McParticle.h for
+                          more details. But there is no more
+                          details... :( */
+      int parent = 0;
+      int parent_decay = 0;
+      int mate = 0;
+      int child[2] = {0};
+
+      // Optionally do skip not final particles.
+      if (status < 0)
+      {
+        if (onlyFinal)
+          continue;
+        decay = 0;
+      }
+
+      /*
+        From the Pythia 8 docs (this information should be here[1]):
+
+        1. mother1 = mother2 = 0: for lines 0 - 2, where line 0
+        represents the event as a whole, and 1 and 2 the two
+        incoming beam particles;
+
+        2. mother1 = mother2 > 0: the particle is a "carbon copy" of
+        its mother, but with changed momentum as a "recoil" effect,
+        e.g. in a shower;
+
+        3. mother1 > 0, mother2 = 0: the "normal" mother case, where
+        it is meaningful to speak of one single mother to several
+        products, in a shower or decay;
+
+        4. mother1 < mother2, both > 0, for abs(status) = 81 - 86:
+        primary hadrons produced from the fragmentation of a string
+        spanning the range from mother1 to mother2, so that all
+        partons in this range should be considered mothers; and
+        analogously for abs(status) = 101 - 106, the formation of
+        R-hadrons;
+
+        5. mother1 < mother2, both > 0, except case 4: particles
+        with two truly different mothers, in particular the
+        particles emerging from a hard 2 → n interaction.
+
+        6. mother2 < mother1, both > 0: particles with two truly
+        different mothers, notably for the special case that two
+        nearby partons are joined together into a status 73 or 74
+        new parton, in the g + q → q case the q is made first mother
+        to simplify flavour tracing.
+
+        We are consider only "normal" mother case (3).
+
+        [1] http://home.thep.lu.se/~torbjorn/pythia82html/Welcome.html
+      */
+      int mother1 = ev[itrk].mother1();
+      int mother2 = ev[itrk].mother2();
+      if (mother1 > 0 && mother2 == 0)
+        parent = mother1;
+      else
+        continue;
+
+      /*
+        This was taken from the same source as for mothers description:
+        1. daughter1 = daughter2 = 0: there are no daughters (so far);
+
+        2. daughter1 = daughter2 > 0: the particle has a "carbon copy"
+        as its sole daughter, but with changed momentum as a "recoil"
+        effect, e.g. in a shower;
+
+        3. daughter1 > 0, daughter2 = 0: each of the incoming beams
+        has only (at most) one daughter, namely the initiator parton
+        of the hardest interaction; further, in a 2 → 1 hard
+        interaction, like q qbar → Z^0, or in a clustering of two
+        nearby partons, the initial partons only have this one
+        daughter;
+
+        4. daughter1 < daughter2, both > 0: the particle has a range
+        of decay products from daughter1 to daughter2;
+
+        5. daughter2 < daughter1, both > 0: the particle has two
+        separately stored decay products (e.g. in backwards evolution
+        of initial-state showers).
+
+        We are consider only forth case where:
+        mother -> daughter1 + ... + daughter2
+        here, daughter2 - daughter1 must equals to 1. In that case
+        only 2 daughter are produced.
+      */
+      int daughter1 = ev[itrk].daughter1();
+      int daughter2 = ev[itrk].daughter2();
+      if (daughter1 != 0 || daughter2 != 0)
+      {
+        if (daughter2 - daughter1 == 1 && daughter1 < daughter2 && daughter1 > 0)
+        {
+          child[0] = daughter1;
+          child[1] = daughter2;
+        }
+        else
+        {
+          continue;
+        }
+      }
+      int index = ev[itrk].index();
+      int pdg = ev[itrk].id();
+      float px = ev[itrk].px();
+      float py = ev[itrk].py();
+      float pz = ev[itrk].pz();
+      float e = ev[itrk].e();
+      float x = ev[itrk].xProd()*1e-12; // In Pythia 8 these values in mm (mm/c).
+      float y = ev[itrk].yProd()*1e-12; // Convert mm (and mm/c) to fm (fm/c).
+      float z = ev[itrk].zProd()*1e-12; // It should be zero for primary particles - i.e. not from
+      float t = ev[itrk].tProd()*1e-12; // decayed particle.
+      // Add new track. FIXME: check nullptr.
+      TClonesArray *mcTrkCol = mcArrays[McArrays::Particle];
+      new ((*mcTrkCol)[mcTrkCol->GetEntries()]) McParticle(index, pdg, status, parent,
+                                                           parent_decay, mate-1, decay, child,
+                                                           px, py, pz, e, x, y, z, t);
+    }
+    // Add an event to DST.
+    tree->Fill();
+  }
+
+  outFile->Write();
+  outFile->Close();
+  return EXIT_SUCCESS;
+}

--- a/pythia8gen.cpp
+++ b/pythia8gen.cpp
@@ -3,13 +3,6 @@
   SPDX-License-Identifier: MIT
 */
 
-/*
-  WARNING: This macro SHOULD NOT be compiled with the `cons' at BNL
-  clusters.  The `cons' will add -D__ROOT_ to the `g++' so in the case
-  of -D__ROOT__ this source file will be expanded to zero.
-*/
-#ifndef __ROOT__
-
 // getopt.
 #include <unistd.h>
 #include <getopt.h>
@@ -461,5 +454,3 @@ main(int argc, char *argv[])
   outFile->Close();
   return EXIT_SUCCESS;
 }
-
-#endif // #ifndef __ROOT__

--- a/urqmd2mc.cpp
+++ b/urqmd2mc.cpp
@@ -10,13 +10,6 @@
  * are discarded.
  */
 
-/*
-  WARNING: This macro SHOULD NOT be compiled with the `cons' at BNL
-  clusters.  The `cons' will add -D__ROOT_ to the `g++' so in the case
-  of -D__ROOT__ this source file will be expanded to zero.
-*/
-#ifndef __ROOT__
-
 // C++ headers
 #include <iostream>
 #include <fstream>
@@ -338,5 +331,3 @@ int main(int argc, char *argv[]) {
   std::cout << "Total bytes were written: " << nout << std::endl;
   return 0;
 }
-
-#endif // #ifndef __ROOT__

--- a/urqmd2mc.cpp
+++ b/urqmd2mc.cpp
@@ -10,6 +10,13 @@
  * are discarded.
  */
 
+/*
+  WARNING: This macro SHOULD NOT be compiled with the `cons' at BNL
+  clusters.  The `cons' will add -D__ROOT_ to the `g++' so in the case
+  of -D__ROOT__ this source file will be expanded to zero.
+*/
+#ifndef __ROOT__
+
 // C++ headers
 #include <iostream>
 #include <fstream>
@@ -331,3 +338,5 @@ int main(int argc, char *argv[]) {
   std::cout << "Total bytes were written: " << nout << std::endl;
   return 0;
 }
+
+#endif // #ifndef __ROOT__


### PR DESCRIPTION
By this PR I would like to add following new features to this project:

- Add new McDstCut class which allows to set a constrains to the particles (tracks) and which could be extended to do the event constrains (cut). As McDstCut is not a child of the TObject (why do one need that anyway?) it was not added to the McDstLinkDef.h.

- Add new McDstQA class which allows to do a QA of the generated MC data from *.mcDst.root files. This class uses McDstCut class in its internals. One could set a particle cut with McDstCut (and event cut in the future (see above)). This class also comes with a simple example macro.

- Add a new converter pythia8gen to run Pythia 8 and save the generated events data to the mcDst.root file. This is also comes with a simple configuration files.

- Add hijing2mc.cpp written by Varvara Semenova and which was tested by her (probably?).