### PR TITLE
Fix building with ROOT 6.23

### DIFF
--- a/McEvent.h
+++ b/McEvent.h
@@ -14,6 +14,7 @@
 // ROOT headers
 #include "TObject.h"
 #include "TLorentzVector.h"
+#include "TString.h"
 
 // Forward declarations
 class TString;


### PR DESCRIPTION
g++ -fPIC -pthread -std=c++11 -m64
-I/home/sh1r4s3/work/git/github/root/build/include -fPIC -W
-Woverloaded-virtual -Wno-deprecated-declarations -Wall -pipe -std=c++11
-D__ROOT__ -I. -O2 -c -o McDst.o McDst.cxx
In file included from McDst.cxx:9:
McEvent.h:158:11: error: field ‘fComment’ has incomplete type ‘TString’
  158 |   TString fComment;
      |           ^~~~~~~~
In file included from
/home/sh1r4s3/work/git/github/root/build/include/TObject.h:17,
                 from McEvent.h:15,
                 from McDst.cxx:9:
/home/sh1r4s3/work/git/github/root/build/include/Rtypes.h:55:7: note:
forward declaration of ‘class TString’
   55 | class TString;
      |       ^~~~~~~
make: *** [Makefile:36: McDst.o] Error 1