### PR TITLE
Fix some comments and McRun methods

### DIFF
--- a/McRun.h
+++ b/McRun.h
@@ -47,17 +47,17 @@ class McRun : public TNamed {
   //
 
   /// Return generator name
-  void generator(TString& gen)       { gen = fGenerator; }
+  TString generator()                { return fGenerator; }
   /// Return generator name
-  void GetGenerator(TString& gen)    { gen = fGenerator; }
+  TString GetGenerator()             { return fGenerator; }
   /// Return comment
-  void comment(TString& cmnt)        { cmnt = fComment; }
+  TString comment()                  { return fComment; }
   /// Return comment
-  void GetComment(TString& cmnt)     { cmnt = fComment; }
+  TString GetComment()               { return fComment; }
   /// Return decayer name
-  void decayer(TString& dec)         { dec = fDecayer; }
+  TString decayer()                  { return fDecayer; }
   /// Return decayer name
-  void GetDecayer(TString& dec)      { dec = fDecayer; }
+  TString GetDecayer()               { return fDecayer; }
   /// Return number of nucleons in the projectile
   Int_t aProj() const                { return (Int_t)fAProj; }
   /// Return number of nucleons in the projectile
@@ -158,6 +158,14 @@ class McRun : public TNamed {
   void setPTarg(const Double_t& pTarg)  { fPTarg = (Float_t)pTarg; }
   /// Set momentum of the target
   void SetPTarg(const Double_t& pTarg)  { setPTarg(pTarg); }
+  /// Set generator name
+  void setGenerator(const TString& gen) { fGenerator = gen; }
+  /// Set generator name
+  void SetGenerator(const TString& gen) { setGenerator(gen); }
+  /// Set comment
+  void setComment(const TString& cmnt)  { fComment = cmnt; }
+  /// Set comment
+  void SetComment(const TString& cmnt)  { setComment(cmnt); }
   /// Set decayer type
   void setDecayer(const TString& decayer)      { fDecayer = decayer; }
   /// Set decayer type

--- a/hijing2mc.cpp
+++ b/hijing2mc.cpp
@@ -1,14 +1,7 @@
 /**
- * urqmd2mc reads UrQMD events from the ftn13 or ftn14 ascii files and
+ * hijing2mc reads HIJING events and
  * converts them to the McDst format and saves on a root file.
- *
- * ftn14 contains snapshots at given times (event steps). The event steps
- * are converted to separate events.
- *
- * ftn13 contains the final snapshot and the freeze-out coordinates.
- * The freeze-out coordinates are used. The final snapshot coordinates
- * are discarded.
- */
+*/
 
 // C++ headers
 #include <iostream>

--- a/macros/analyseMcDst.C
+++ b/macros/analyseMcDst.C
@@ -108,7 +108,7 @@ void analyseMcDst(const Char_t *inFile = "../test.mcDst.root",
       break;
     }
 
-    // Retrieve femtoDst
+    // Retrieve mcDst
     McDst *dst = myReader->mcDst();
 
     // Retrieve event information
@@ -126,7 +126,7 @@ void analyseMcDst(const Char_t *inFile = "../test.mcDst.root",
     // Track loop
     for(Int_t iTrk=0; iTrk<nTracks; iTrk++) {
 
-      // Retrieve i-th femto track
+      // Retrieve i-th MC track
       McParticle *particle = dst->particle(iTrk);
 
       if (!particle) continue;

--- a/macros/processMcDstStandalone.cpp
+++ b/macros/processMcDstStandalone.cpp
@@ -138,7 +138,7 @@ int main(int argc, char* argv[]) {
       break;
     }
 
-    // Retrieve femtoDst
+    // Retrieve mcDst
     McDst *dst = myReader->mcDst();
 
     // Retrieve event information
@@ -156,7 +156,7 @@ int main(int argc, char* argv[]) {
     // Track loop
     for(Int_t iTrk=0; iTrk<nTracks; iTrk++) {
 
-      // Retrieve i-th femto track
+      // Retrieve i-th MC track
       McParticle *particle = (McParticle*)dst->particle(iTrk);
 
       if (!particle) continue;


### PR DESCRIPTION
Modified:
- McRun.h: fGenerator and fComment getters fixed and setters added
- hijing2mc.cpp: Copy-Paste pattern failed, description needs to be expanded properly
- macros/analyseMcDst.C: "femto" replaced by "mc"
- macros/processMcDstStandalone.cpp: "femto" replaced by "mc"